### PR TITLE
Wifi only upload

### DIFF
--- a/appconfig/default.json
+++ b/appconfig/default.json
@@ -90,5 +90,8 @@
       "caution_threshold_bytes": 300000000,
       "assumed_mb_per_minute": 90
     }
+  },
+  "user_preference_defaults": {
+    "wifi_upload_only": false
   }
 }

--- a/appconfig/eqis.json
+++ b/appconfig/eqis.json
@@ -91,5 +91,8 @@
       "caution_threshold_bytes": 300000000,
       "assumed_mb_per_minute": 90
     }
+  },
+  "user_preference_defaults": {
+    "wifi_upload_only": false
   }
 }

--- a/appconfig/mobilize.json
+++ b/appconfig/mobilize.json
@@ -90,5 +90,8 @@
       "caution_threshold_bytes": 300000000,
       "assumed_mb_per_minute": 90
     }
+  },
+  "user_preference_defaults": {
+    "wifi_upload_only": false
   }
 }

--- a/www/blocks/page/_profile.scss
+++ b/www/blocks/page/_profile.scss
@@ -1,3 +1,10 @@
+$profile-item-switch-width: 80px;
+$profile-item-switch-spacing: 1px;
+$profile-item-switch-height: 32px;
+$profile-item-switch-font-size: 14px;
+$profile-item-switch-switch-font-size: 10px;
+$profile-item-switch-border-width: 1px;
+
 #profile-region {
   .text-container {
     position: relative;
@@ -24,6 +31,88 @@
       background: $modal-activate-background;
       color: $modal-activate-font-color;
       padding: $global-form-control-padding*1.5;
+    }
+  }
+  //TODO: abstract this switch as a base app component.
+  .profile-item-switch {
+    cursor: pointer;
+    position: relative;
+  
+    .enable-switch-container {
+      float: right;
+      width: $profile-item-switch-width;
+      text-align: right;
+    }
+  
+    .enable-switch {
+  
+      width: $profile-item-switch-width;
+      height: $profile-item-switch-height;
+      position: relative;
+      font-size: $profile-item-switch-switch-font-size;
+      margin: 0;
+      text-transform: uppercase;
+      font-weight: bold;
+  
+      input {
+        position: absolute;
+        margin-left: -9999px;
+        visibility: hidden;
+      }
+  
+      input + label {
+        display: block;
+        position: relative;
+        cursor: pointer;
+        outline: none;
+        user-select: none;
+        padding: $profile-item-switch-spacing;
+        width: $profile-item-switch-width;
+        height: $profile-item-switch-height;
+        background-color: #fff; // change this to same as input + label:after color to get a border the same color as the button
+        border: $profile-item-switch-border-width solid #ddd;
+        transition: background 0.4s;
+      }
+  
+      input + label:before,
+      input + label:after {
+        display: block;
+        position: absolute;
+        content: "";
+      }
+  
+      input + label:before {
+        top: $profile-item-switch-spacing;
+        left: $profile-item-switch-spacing;
+        bottom: $profile-item-switch-spacing;
+        right: $profile-item-switch-spacing;
+        background-color: #fff;
+        transition: background 0.4s;
+      }
+  
+      input + label:after {
+        top: $profile-item-switch-spacing;
+        left: $profile-item-switch-spacing;
+        bottom: $profile-item-switch-spacing;
+        width: ($profile-item-switch-width / 2) - ($profile-item-switch-spacing * 2) - ($profile-item-switch-border-width * 2);
+        text-align: center;
+        background-color: #b00;
+        padding-top: ($profile-item-switch-height - $profile-item-switch-spacing * 4 - $profile-item-switch-switch-font-size) / 2 - 1;
+        color: #fff;
+        transition: margin 0.4s, background 0.4s;
+        content: 'Off';
+      }
+  
+      input:checked + label {
+        background-color: #fff; // change this to same as input:checked + label:after color to get a border the same color as the button
+      }
+  
+      input:checked + label:after {
+        margin-left: $profile-item-switch-width / 2;
+        background-color: #00aeff;
+        color: #fff;
+        content: 'On';
+      }
     }
   }
 }

--- a/www/js/backbone/apps/profile/show/show_view.js.coffee
+++ b/www/js/backbone/apps/profile/show/show_view.js.coffee
@@ -5,11 +5,23 @@
     template: "profile/show/info"
     triggers:
       "click .change-password": "password:clicked"
+    events: ->
+      "change #enable-switch-wifi": "setWifiUploadOnly"
+    setWifiUploadOnly: (e) ->
+      e.preventDefault()
+      e.stopPropagation()
+      App.request 'user:preferences:set', 'wifi_upload_only', @$el.find("#enable-switch-wifi").prop('checked') is true
+    checkEnabledWifiOnly: ->
+      @$el.find("#enable-switch-wifi").prop('checked', true)
     serializeData: ->
       data = @model.toJSON()
       data.showPassword = App.request "credentials:ispassword"
       data.serverPath = App.request "serverpath:current"
       data
+    onRender: ->
+      wifiUploadOnly = App.request "user:preferences:get", 'wifi_upload_only'
+      console.log "setting wifi upload only to: "+wifiUploadOnly
+      if wifiUploadOnly then @checkEnabledWifiOnly()
 
   class Show.Layout extends App.Views.Layout
     template: "profile/show/show_layout"

--- a/www/js/backbone/apps/profile/show/templates/info.jst.eco
+++ b/www/js/backbone/apps/profile/show/templates/info.jst.eco
@@ -8,4 +8,14 @@ Logged in as <strong><%= @username %></strong>
 </div>
 <% end %>
 <br />
+<div class="profile-item-switch">
+  <div class="enable-switch-container">
+    <div class="enable-switch">
+      <input id="enable-switch-wifi" type="checkbox">
+      <label for="enable-switch-wifi"></label>
+    </div>
+  </div>
+  WiFi-only uploads
+</div>
+<br />
 <small>Connected to server <strong><%= @serverPath %></strong></small>

--- a/www/js/backbone/apps/survey_fail/survey_fail_app.js.coffee
+++ b/www/js/backbone/apps/survey_fail/survey_fail_app.js.coffee
@@ -50,3 +50,6 @@
   App.vent.on "survey:upload:failure:network", (responseData, errorText, surveyId) ->
     # placeholder for network errors handler.
     API.uploadFailureGeneral responseData, "", "Network Error", surveyId
+
+  App.vent.on "survey:upload:failure:wifionly", (responseData, errorText, surveyId) ->
+    API.uploadFailureGeneral responseData, "Cannot Upload: ", "User preferences set to only upload on wifi.", surveyId

--- a/www/js/backbone/apps/uploadqueue/uploadqueue_app.js.coffee
+++ b/www/js/backbone/apps/uploadqueue/uploadqueue_app.js.coffee
@@ -84,3 +84,6 @@
   App.vent.on "uploadqueue:upload:failure:network", (responseData, errorText, itemId) ->
     # placeholder for network errors handler.
     API.queueFailureGeneral responseData, "", "Network Error", itemId
+
+  App.vent.on "uploadqueue:upload:failure:wifionly", (responseData, errorText, itemId) ->
+    API.queueFailureGeneral responseData, "Cannot Upload:", "User preferences set to only upload on wifi.", itemId

--- a/www/js/backbone/entities/_abstract/userpreferences.js.coffee
+++ b/www/js/backbone/entities/_abstract/userpreferences.js.coffee
@@ -1,0 +1,41 @@
+@Ohmage.module "Entities", (Entities, App, Backbone, Marionette, $, _) ->
+
+  # UserPrefences entity.
+  # This pertains to storing, retrieving and setting user preferences.
+
+  class Entities.UserPreferences extends Entities.Model
+
+  storedPreferences = false
+
+  API =
+    init: ->
+      App.request "storage:get", 'user_preferences', ((result) =>
+        console.log 'saved user preferences retrieved from storage'
+        storedPreferences = new Entities.UserPreferences result
+        App.vent.trigger "userpreferences:saved:init:success"
+      ), =>
+        console.log 'saved user preferences not retrieved from storage'
+        storedPreferences = new Entities.UserPreferences
+          wifi_upload_only: App.custom.user_preference_defaults.wifi_upload_only
+        App.vent.trigger "userpreferences:saved:init:failure"
+
+    updateLocal: (callback) ->
+      App.execute "storage:save", 'user_preferences', storedPreferences.toJSON(), callback
+
+    getPreference: (preference) ->
+      storedPreferences.get(preference)
+
+    setPreference: (preference, state) ->
+      storedPreferences.set(preference, state)
+      @updateLocal( =>
+        console.log "UserPreferences entity saved in localStorage"
+      )
+
+  App.on "before:start", ->
+    API.init()
+
+  App.reqres.setHandler "user:preferences:get", (preference) ->
+    API.getPreference preference
+
+  App.reqres.setHandler "user:preferences:set", (preference, state) ->
+    API.setPreference preference, state

--- a/www/js/backbone/entities/_abstract/userpreferences.js.coffee
+++ b/www/js/backbone/entities/_abstract/userpreferences.js.coffee
@@ -31,6 +31,13 @@
         console.log "UserPreferences entity saved in localStorage"
       )
 
+    clear: ->
+      storedPreferences = new Entities.UserPreferences
+
+      App.execute "storage:clear", 'user_preferences', ->
+        console.log 'user preferences erased'
+        App.vent.trigger "userpreferences:saved:cleared"
+
   App.on "before:start", ->
     API.init()
 
@@ -39,3 +46,6 @@
 
   App.reqres.setHandler "user:preferences:set", (preference, state) ->
     API.setPreference preference, state
+
+  App.vent.on "credentials:cleared", ->
+    API.clear()

--- a/www/js/backbone/entities/uploader/queue_all.js.coffee
+++ b/www/js/backbone/entities/uploader/queue_all.js.coffee
@@ -95,3 +95,6 @@
   App.vent.on "uqall:upload:failure:network", (responseData, errorText, itemId) ->
     # placeholder for network errors handler.
     API.queueFailureGeneral "Problem with Network:", errorText, itemId
+
+  App.vent.on "uqall:upload:failure:wifionly", (responseData, errorText, itemId) ->
+    API.queueFailureGeneral "Cannot Upload:", "User preferences set to only upload on wifi.", itemId

--- a/www/js/backbone/entities/uploader/uploader.js.coffee
+++ b/www/js/backbone/entities/uploader/uploader.js.coffee
@@ -219,13 +219,21 @@
     else
       uploadType = App.request 'uploadqueue:item:uploadtype', itemId
 
-    console.log 'uploadType', uploadType
-    App.vent.trigger "uploadtracker:active"
+    # on device, no wifi and user preference set to only upload on wifi 
+    cellNetworkTypes = [Connection.CELL, Connection.CELL_2G, Connection.CELL_3G, Connection.CELL_4G] if App.device.isNative
+    if App.device.isNative and navigator.connection.type in cellNetworkTypes and App.request "user:preferences:get", 'wifi_upload_only'
+      console.log "device not on wifi, user preferences requires for upload."
+      App.vent.trigger "#{context}:upload:failure:wifionly", responseData, "Not on WiFi", itemId
+      App.vent.trigger "loading:hide"
 
-    switch uploadType
-      when 'video'
-        API.videoUploader context, responseData, itemId
-      when 'file'
-        API.documentUploader context, responseData, itemId
-      else
-        API.ajaxUploader context, responseData, itemId
+    else # continue with upload in all other cases.
+      console.log 'uploadType', uploadType
+      App.vent.trigger "uploadtracker:active"
+  
+      switch uploadType
+        when 'video'
+          API.videoUploader context, responseData, itemId
+        when 'file'
+          API.documentUploader context, responseData, itemId
+        else
+          API.ajaxUploader context, responseData, itemId


### PR DESCRIPTION
a basic implementation for #655.

Details of implementation:
  * New base entity (UserPreferences)
    * generically implemented as this could be useful for other things down the road.
    * offers a getter and setter method for an arbitrary preference
    * Defaults of these preferences can/should be specific in config files
    * Persists user changes to localstorage so they survive app death.
  * Added row to profile page for wifi-upload-only preference
    * rough css, Profile page still has some rudimentary styling so I didn't go overboard on this..
    * copied switch css from reminder page (noted that this could be abstracted, but I'm terrible at CSS and know nothing about blocks...so it's probably best if I don't do this).
    * toggling switch sets the preference (OFF = normal state, ON = app will *not* upload when on cell network.
  * Set `if` block for `native && wifi-upload-only && on cell network` in uploader:new method.
    * Continue to allow user to "retry" even with this failure (existing code appears to assume this)
    * added upload failure state for `wifionly` to all upload contexts.
    * this preference is not available in the browser (profile page is disabled currently), so "preference" is ignored if in browser.

@ctrance -- this has yet to be tested on iOS as I don't have iOS device with a cell connection (and it's required for testing the feature, ha!). Could you test this with the builds labeled `ohmageX-steve` on https://apps.ohmage.org ? -- note that I haven't pulled in @wrenr's recent dashboard changes (and pull from his branch mid-implementation) so it's best to report issues only relating to:
  * profile page (displaying wifi switch, toggling switch)
  * survey uploads (both from survey context and upload queue context)
    * should always upload if on wifi as well as if on cell and preference is set to "off" (which is default)
    * should never upload if on cell network and preference is set to "on" (survey upload attempts and upload queue single survey attempts should provide info about the preference being on, "upload all attempts" currently do not specify errors.
  * Killing app should keep preference. 
  * Logging out should set back to default 