### PR TITLE
add link on surveys page to visit campaigns page for more surveys

### DIFF
--- a/www/js/backbone/apps/surveys/list/list_view.js.coffee
+++ b/www/js/backbone/apps/surveys/list/list_view.js.coffee
@@ -75,6 +75,12 @@
       infobuttonRegion: "#infobutton-region"
       selectorRegion: "#selector-region"
       listRegion: "#list-region"
+    events: ->
+     "click #campaign-link": "campaignLinkClicked"
     serializeData: ->
       data = @collection.findWhere(chosen: true).toJSON()
       data
+    campaignLinkClicked: (e) ->
+      e.preventDefault()
+      console.log('link clicked')
+      App.navigate "campaigns", { trigger: true }

--- a/www/js/backbone/apps/surveys/list/templates/list_layout.jst.eco
+++ b/www/js/backbone/apps/surveys/list/templates/list_layout.jst.eco
@@ -5,3 +5,9 @@
 </header>
 <h3 class="hide-accessible"><%= @name %> Saved <%= @dictionary('pages','survey') %></h3>
 <div id="list-region"></div>
+<div class="text-container">
+  <p>Missing a <%= @dictionary('page','survey') %>?
+     Download more from the 
+     <a href='#' id="campaign-link"><%= @dictionary('pages','campaign') %></a> page.
+  </p>
+</div>


### PR DESCRIPTION
Added very basic link to the bottom of surveys page as a helper to users who don't see the campaign they are looking for.

Opted to do this **not** in the surveys_empty view as it applies to both cases.

@wrenr we need this for the mobilize deployment, but will just deploy from our fork if you don't have a chance to look at the PR before our deadline.

Additionally, I implemented the link clicking as it appears to work in https://github.com/ucla/ohmageX/blob/develop/www/js/backbone/apps/footer/show/show_view.js.coffee