### PR TITLE
add build task for jenkins parallel build plan

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -393,3 +393,13 @@ module.exports = (grunt) ->
     "exec:android_build" # must pass it through a custom exec to change cwd
   ]
 
+  grunt.registerTask "jenkins_build", [
+    "dev"
+    "clean:hybrid_build"
+    "copy:hybrid_build"
+    "clean:cordova_www"
+    "copy:cordova_www"
+    "template:cordova_config"
+    "clean:cordova_config"
+    "copy:cordova_config"
+  ]


### PR DESCRIPTION
@wrenr I noticed the existing grunt build tasks made it a bit hard to do the parallel/custom builds in the way that made the most sense (in essence, missing a task that de-couples the www build from apk/ipa generation).  

The current way I'm doing builds:
1. git checkout, bundle install, npm install, webblocks_build, mobile_firstrun
2. [in parallel, per config] webblocks_build (with config), "jenkins_build" (with config)

This leaves me with N ready-to-be-built clones of the same checkout so I can make apk/ipa outputs where applicable (but not make them when they are not needed, eg "eqis" doesn't need an ios build). 

Feel free to reject if you prefer I generate this task locally, or rename the task if you prefer another name. Currently there is android_www_build and ios_www_build, but it didn't seem right to just do "www_build"..so I just opted to name it what I'm using it for.